### PR TITLE
Fix for 'isVisible' of undefined

### DIFF
--- a/lib/auto-reveal-active-file.js
+++ b/lib/auto-reveal-active-file.js
@@ -10,7 +10,7 @@ module.exports = {
             {
                 var treeView = atom.packages.getActivePackage('tree-view');
 
-                if (treeView && treeView.mainModule.treeView.isVisible())
+                if (treeView && treeView.mainModule && treeView.mainModule.treeView && treeView.mainModule.treeView.isVisible())
                 {
                     var activePane = atom.workspace.getActivePane()
                     ,   workspaceView = atom.views.getView(atom.workspace);


### PR DESCRIPTION
Fix for Cannot read property 'isVisible' of undefined.

Check that the object is available before calling "isVisible"